### PR TITLE
Fix dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ Special thanks to the following people for submitting patches.
 
 ## Changelog
 
-See [CHANGELOG](devices/blob/master/CHANGELOG.md)
+See [CHANGELOG](redis-throttle/blob/master/CHANGELOG.md)
 
 
 ## Copyright
 
 Redis Throttle is free and unencumbered public domain software.
-See [LICENCE](devices/blob/master/LICENSE.md)
+See [LICENCE](redis-throttle/blob/master/LICENSE.md)
 


### PR DESCRIPTION
The links for changelog and license pointed to a non-existing “devices” repo, I changed them to redis-throttle.
