### PR TITLE
Update README installation instructions for Rails 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,20 @@ Devices API is tested against MRI 1.9.3.
 Update your gem file and run `bundle`
 
 ```ruby
-gem 'redis-throttle', git: 'git@github.com:andreareginato/redis-throttle.git'
+gem 'redis-throttle', git: 'git://github.com/andreareginato/redis-throttle.git'
 ```
 
 ## Rails Example
 
 ```ruby
-# Limit the daily numebr of requests to 2500
-config.middleware.use Rack::RedisThrottle::Daily, max: 2500
+# At the top of config/application.rb
+require 'rack/redis_throttle'
+
+# Inside the class of config/application.rb
+class Application < Rails::Application
+  # Limit the daily number of requests to 2500
+  config.middleware.use Rack::RedisThrottle::Daily, max: 2500
+end
 ```
 
 ## Sinatra example 


### PR DESCRIPTION
I've updated the README because the original one was missing some steps. In order for the gem to work in Rails 3.x, you need to use the `git://` version of the URL in the Gemfile, not `git@github`. And in `config/application.rb`, you must `require rack/redis_throttle`. Otherwise, you will get `uninitialized constant Rack::RedisThrottle (NameError)`.
