### PR TITLE
Convert specs to RSpec 3.0 with Transpec and add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+services:
+  - redis-server
+rvm:
+  - 1.9.3
+  - jruby-19mode
+  - rbx
+  - 2.0.0
+  - 2.1.0
+matrix:
+  allow_failures:
+    - rvm: rbx

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
-require 'bundler'
-Bundler::GemHelper.install_tasks
+require 'bundler/gem_tasks'
+
+task default: :spec
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new do |t|
+  t.rspec_opts = ['--color', '--format doc']
+end
+

--- a/redis_throttle.gemspec
+++ b/redis_throttle.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'redis-namespace'
   gem.add_dependency 'activesupport'
 
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'foreman'

--- a/spec/rack/redis_throttle/daily_no_redis_spec.rb
+++ b/spec/rack/redis_throttle/daily_no_redis_spec.rb
@@ -20,11 +20,11 @@ describe Rack::RedisThrottle::Daily do
           before { get '/foo' }
 
           it 'returns a 200 status' do
-            last_response.status.should == 200
+            expect(last_response.status).to eq(200)
           end
 
           it 'returns the remaining requests header' do
-            last_response.headers['X-RateLimit-Remaining'].should == '5000'
+            expect(last_response.headers['X-RateLimit-Remaining']).to eq('5000')
           end
         end
       end

--- a/spec/rack/redis_throttle/daily_spec.rb
+++ b/spec/rack/redis_throttle/daily_spec.rb
@@ -28,21 +28,21 @@ describe Rack::RedisThrottle::Daily do
         before { get '/foo' }
 
         it 'returns a 200 status' do
-          last_response.status.should == 200
+          expect(last_response.status).to eq(200)
         end
 
         it 'returns the requests limit headers' do
-          last_response.headers['X-RateLimit-Limit'].should_not be_nil
+          expect(last_response.headers['X-RateLimit-Limit']).not_to be_nil
         end
 
         it 'returns the remaining requests header' do
-          last_response.headers['X-RateLimit-Remaining'].should_not be_nil
+          expect(last_response.headers['X-RateLimit-Remaining']).not_to be_nil
         end
 
         it 'decreases the available requests' do
           previous = last_response.headers['X-RateLimit-Remaining'].to_i
           get '/', {}, 'AUTHORIZATION' => 'Bearer <token>'
-          previous.should == last_response.headers['X-RateLimit-Remaining'].to_i + 1
+          expect(previous).to eq(last_response.headers['X-RateLimit-Remaining'].to_i + 1)
         end
       end
 
@@ -52,11 +52,11 @@ describe Rack::RedisThrottle::Daily do
         before { get '/foo' }
 
         it 'returns a 403 status' do
-          last_response.status.should == 403
+          expect(last_response.status).to eq(403)
         end
 
         it 'returns a rate limited exceeded body' do
-          last_response.body.should == '403 Forbidden (Rate Limit Exceeded)'
+          expect(last_response.body).to eq('403 Forbidden (Rate Limit Exceeded)')
         end
 
         describe 'when comes the new day' do
@@ -70,7 +70,7 @@ describe Rack::RedisThrottle::Daily do
           after  { Timecop.return }
 
           it 'returns a 200 status' do
-            last_response.status.should == 200
+            expect(last_response.status).to eq(200)
           end
 
           it 'returns a new rate limit' do


### PR DESCRIPTION
1. Ran transpec to convert to RSpec 3.x syntax
2. Added a .travis.yml for Travis CI

@andreareginato if you merge this PR you'll need to go to http://travis-ci.org to activate Travis CI for this repo.  This will run specs on every PR and change to master.
