### PR TITLE
Add mock_redis to the gem dependencies

### DIFF
--- a/redis_throttle.gemspec
+++ b/redis_throttle.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hiredis'
   gem.add_dependency 'redis-namespace'
   gem.add_dependency 'activesupport'
+  gem.add_dependency 'mock_redis'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Hi,

First thanks for this gem. I had to add `mock_redis` in my `Gemfile` to use the mock in my tests (`rack/redis_throttle/testing/connection`). 