### PR TITLE
Fix some problems

### DIFF
--- a/lib/rack/redis_throttle.rb
+++ b/lib/rack/redis_throttle.rb
@@ -3,9 +3,6 @@ require 'rack/throttle'
 require 'redis'
 require 'hiredis'
 require 'redis-namespace'
-require 'active_support/core_ext/hash/reverse_merge'
-require 'active_support/core_ext/time/calculations'
-require 'active_support/core_ext/date/calculations'
 
 module Rack
   module RedisThrottle

--- a/lib/rack/redis_throttle/connection.rb
+++ b/lib/rack/redis_throttle/connection.rb
@@ -5,9 +5,9 @@ module Rack
     class Connection
 
       def self.create(options={})
-        url = redis_provider || 'redis://localhost:6379/0'
-        options.reverse_merge!({ url: url })
-        client = Redis.connect(url: options[:url], driver: :hiredis)
+        options[:url] = redis_provider || 'redis://localhost:6379/0' unless options.has_key?(:url)
+        method = Redis::VERSION.to_i >= 3 ? :new : :connect
+        client = Redis.send(method, url: options[:url], driver: :hiredis)
         Redis::Namespace.new("redis-throttle:#{ENV['RACK_ENV']}:rate", redis: client)
       end
 

--- a/lib/rack/redis_throttle/limiter.rb
+++ b/lib/rack/redis_throttle/limiter.rb
@@ -5,7 +5,7 @@ module Rack
     class Limiter < Rack::Throttle::Limiter
 
       def initialize(app, options = {})
-        options.reverse_merge!({ cache: Rack::RedisThrottle::Connection.create })
+        options[:cache] = Rack::RedisThrottle::Connection.create(options) unless options.has_key?(:cache)
         @app, @options = app, options
       end
 
@@ -53,7 +53,7 @@ module Rack
         begin
           key   = cache_key(request)
           count = cache.incr(key)
-          cache.expire(key, 1.day) if count == 1
+          cache.expire(key, 86400) if count == 1
           count
         rescue Redis::BaseConnectionError => e
           puts "ERROR: Redis connection not available. Rescuing cache.incr(key)" if ENV['DEBUG']

--- a/redis_throttle.gemspec
+++ b/redis_throttle.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'redis'
   gem.add_dependency 'hiredis'
   gem.add_dependency 'redis-namespace'
-  gem.add_dependency 'activesupport'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
@@ -45,4 +44,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'fuubar'
   gem.add_development_dependency 'growl'
+  gem.add_development_dependency 'activesupport'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rack/test'
 require 'mock_redis'
 require 'rspec'
 require 'timecop'
+require 'active_support/core_ext/time/calculations'
 
 require File.dirname(__FILE__) + '/fixtures/fake_app'
 


### PR DESCRIPTION
1. `Redis#connect` are outdated in version 3, removed after upgrading to version 4
2. `merge` method is wasteful, it returns a new object
3. `activesupport` moved to development dependency